### PR TITLE
Fix Uninitialized Variable Bug in Sale Structure

### DIFF
--- a/main.c
+++ b/main.c
@@ -269,16 +269,18 @@ void buy_car() {
     // Update car stock
     cars[car_index].stock -= quantity;
 
-    // Record sale data
-    Sale sale;
-    strcpy(sale.customer_name, customer_name);
-    sale.customer_age = customer_age;
-    sale.total_price = total_price;
-    sale.discount = with_plug ? DISCOUNT_PERCENTAGE * 100 : 0;
-    sale.num_cars = quantity;
-    strcpy(sale.date, date);
-    strcpy(sale.car_model, cars[car_index].model);  // Store the car model in the sales array
-    sales[num_sales] = sale;  // Store the sale in the sales array
+	// Record sale data
+	Sale sale;
+	strcpy(sale.customer_name, customer_name);
+	sale.customer_age = customer_age;
+	sale.total_price = total_price;
+	sale.discount = with_plug ? DISCOUNT_PERCENTAGE * 100 : 0;
+	sale.num_cars = quantity;
+	strcpy(sale.date, date);
+	strcpy(sale.car_model, cars[car_index].model);  // Store the car model in the sales array
+	sale.rating = 0;	// Initialize the sale.rating to a default value, e.g., 0
+	sales[num_sales] = sale;	// Store the sale in the sales array
+
 
     printf("Purchase successful!\n");
     printf("You bought %d %d Mercedes Benz %s AMG for %d GBP.\n", quantity, cars[car_index].year, cars[car_index].model, total_price);


### PR DESCRIPTION
#### Description
This PR addresses a bug identified using cppcheck, where the `sale.rating` variable in the `Sale` structure was uninitialized before being assigned to the `sales` array. This bug could potentially lead to undefined behavior or incorrect data being stored.

#### Changes Made
- Initialized the `sale.rating` field to a default value (0) before assigning the `sale` structure to the `sales` array.
- Ensured that all fields in the sale structure are properly initialized.
- Formatted the code with tabs at the beginning of each line for consistency.

#### Code Changes
```c
	// Record sale data
	Sale sale;
	strcpy(sale.customer_name, customer_name);
	sale.customer_age = customer_age;
	sale.total_price = total_price;
	sale.discount = with_plug ? DISCOUNT_PERCENTAGE * 100 : 0;
	sale.num_cars = quantity;
	strcpy(sale.date, date);
	strcpy(sale.car_model, cars[car_index].model);  // Store the car model in the sales array
	sale.rating = 0;	// Initialize the sale.rating to a default value, e.g., 0
	sales[num_sales] = sale;	// Store the sale in the sales array
```

#### Testing
- Verified that the `sale` structure is correctly initialized and stored in the `sales` array.
- Ran cppcheck again to ensure no other uninitialized variable warnings are present.
- Tested the affected functionality to confirm no regression issues.

#### Additional Notes
- This fix ensures that the application behaves correctly and maintains data integrity by initializing all fields in the `sale` structure.
- The bug was identified using cppcheck, a static analysis tool, which helps catch such issues early in the development process.

Please review the changes and let me know if any further modifications are required.
